### PR TITLE
cleanup: remove all code related to GCQ commands dealing with IOP

### DIFF
--- a/sw/AMI/app/cmd_handlers/cmd_cfgmem_program.c
+++ b/sw/AMI/app/cmd_handlers/cmd_cfgmem_program.c
@@ -230,11 +230,11 @@ static int do_cmd_cfgmem_program(struct app_option *options, int num_args, char 
             char command[255];
 
             // using sudo, we cannot access user variables, we are in root
-            printf("[INFO]: vivado_path  %s \n", vivado_path);
-            printf("[INFO]: tool_version %s \n\n", tool_version);
+            printf("[INFO]: XILINX_VIVADO_PATH = %s \n", vivado_path);
+            printf("[INFO]: XILINX_TOOL_VERSION = %s \n\n", tool_version);
 
             if (!vivado_path || !tool_version) {
-                fprintf(stderr, "Required environment variables not set: you must launch this command with -E !\n");
+                fprintf(stderr, "Required environment variables not set: if using sudo you may want to add -E to keep user env !\n");
                 exit(EXIT_FAILURE);
             }
 

--- a/sw/AMI/driver/amc_proxy.c
+++ b/sw/AMI/driver/amc_proxy.c
@@ -635,57 +635,13 @@ static void amc_proxy_cmd_complete(struct amc_proxy_instance *inst, struct com_q
                         if (inst->event_cb) {
                                 inst->event_cb(inst->proxy_id,
                                                AMC_PROXY_EVENT_RESPONSE_COMPLETE,
-                                               cmd,
-                                               NULL);
+                                               cmd);
                         }
                         mutex_unlock(&(inst->lock));
                         return;
         }
     }
-    if (ccmd->hdr.cid > AMC_TRIGGERED_COMMAND_ID) {
-        struct amc_proxy_cmd_response *cmd_resp =
-                (struct amc_proxy_cmd_response*)ccmd;
-        PR_INFO("amc triggered cmd received %d", ccmd->hdr.cid);
 
-        PR_INFO("amc triggered cmd payload %x %x cnt %d", cmd_resp->default_payload.resvd0, cmd_resp->default_payload.resvd1, ccmd->hdr.cid-AMC_TRIGGERED_COMMAND_ID);
-
-        // create a new command for this AMC triggered command
-        cmd = kzalloc(sizeof(struct amc_proxy_cmd_struct), GFP_KERNEL);
-        if (!cmd) {
-            PR_ERR("Failed to allocate kernel memory for cmd");
-            mutex_unlock(&(inst->lock));
-            return;
-        }
-        cmd->cmd_cid = ccmd->hdr.cid;
-        cmd->cmd_suppress_dbg = false;
-        /* Make a copy of the response before removing from the list */
-        memcpy(&cmd->cmd_response, &cmd_resp->default_payload, sizeof(cmd_resp->default_payload));
-
-        cmd->cmd_response_code = cmd_resp->ret;
-
-        /* Suppress hearbeat message so as not to flood dmesg */
-        if (cmd->cmd_suppress_dbg == false) {
-                PR_DBG(
-                        "cmd=%d cid=0x%X cstate=0x%X specific=0x%X state=0x%X res=0x%X ret=0x%X",
-                        cmd->cmd_cid,
-                        ccmd->hdr.cid,
-                        ccmd->hdr.cstate,
-                        ccmd->hdr.specific,
-                        ccmd->hdr.state,
-                        ccmd->result,
-                        ccmd->rcode
-                );
-        }
-
-        if (inst->event_cb) {
-            inst->event_cb(inst->proxy_id,
-                           AMC_PROXY_EVENT_TRIGGERED_BY_AMC,
-                           cmd,
-                           inst->amc_ctrl_ctxt);
-        }
-        mutex_unlock(&(inst->lock));
-        return;
-    }
     PR_ERR("No matching cid %d found, unexpected response", ccmd->hdr.cid);
     mutex_unlock(&(inst->lock));
 }
@@ -745,8 +701,7 @@ static void amc_proxy_submitted_cmds_drain(struct amc_proxy_instance *inst)
                         if (inst->event_cb) {
                                 inst->event_cb(inst->proxy_id,
                                                AMC_PROXY_EVENT_RESPONSE_TIMEOUT,
-                                               cmd,
-                                               NULL);
+                                               cmd);
                         }
                 }
         }
@@ -812,8 +767,7 @@ static void amc_proxy_submitted_cmd_check_timeout(struct amc_proxy_instance *ins
                         if (inst->event_cb) {
                                 inst->event_cb(inst->proxy_id,
                                                AMC_PROXY_EVENT_RESPONSE_TIMEOUT,
-                                               cmd,
-                                               NULL);
+                                               cmd);
                         }
                 }
         }
@@ -888,14 +842,15 @@ static int complete_response_thread(void *data)
                     if (ackq_head + ackq_pending_words >= AMC_IOPACK_MAX_WORDS) {
                         PR_INFO("Reading %d words @ offset %x - not finished",
                                 AMC_IOPACK_MAX_WORDS - ackq_head,
-                                (AMC_IOPACK_ADDR_DATA_START + (ackq_head * sizeof(uint32_t))) );
+                                (uint32_t)(AMC_IOPACK_ADDR_DATA_START + (ackq_head * sizeof(uint32_t))) );
                         memcpy_iopack_payload_from_device(amc_proxy_inst->amc_ctrl_ctxt, AMC_IOPACK_ADDR_DATA_START +
                                 (ackq_head * sizeof(uint32_t)), iopAck, (AMC_IOPACK_MAX_WORDS - ackq_head) * sizeof(uint32_t));
                         ackq_pending_words -= (AMC_IOPACK_MAX_WORDS - ackq_head);
                         iopAck += (AMC_IOPACK_MAX_WORDS - ackq_head);
                         ackq_head = 0;
                     }
-                    PR_INFO("Reading %d words @ offset %x", ackq_pending_words, AMC_IOPACK_ADDR_DATA_START + (ackq_head * sizeof(uint32_t)));
+                    PR_INFO("Reading %d words @ offset %x", ackq_pending_words,
+                                (uint32_t)(AMC_IOPACK_ADDR_DATA_START + (ackq_head * sizeof(uint32_t))));
                     if (ackq_pending_words > 0) {
                         memcpy_iopack_payload_from_device(amc_proxy_inst->amc_ctrl_ctxt, AMC_IOPACK_ADDR_DATA_START +
                                 (ackq_head * sizeof(uint32_t)), iopAck, ackq_pending_words * sizeof(uint32_t));
@@ -1455,58 +1410,6 @@ int amc_proxy_request_peek_poke(struct amc_proxy_cmd_struct *cmd, struct amc_pro
     return ret;
 }
 
-
-/*
- * Create a iop push request
- */
-int amc_proxy_request_iop_push(struct amc_proxy_cmd_struct *cmd, struct amc_proxy_ami_iop_push *iop_push) {
-
-    // initialize return using Error Permission
-    int ret = -EPERM;
-
-    struct amc_proxy_list_entry *amc_ctxt = NULL;
-
-    if (!cmd)
-        return -EINVAL;
-
-    amc_ctxt = amc_proxy_find_matching_proxy_instance(cmd->cmd_fw_if_gcq);
-
-    if (amc_ctxt && amc_ctxt->inst.initialised) {
-        struct amc_proxy_cmd_request request_cmd_entry = {{{{0}}}};
-        struct amc_proxy_cmd_request_hdr *request_hdr = NULL;
-
-        request_hdr = &(request_cmd_entry.hdr);
-        request_hdr->opcode = AMC_PROXY_CMD_OPCODE_AMI_IOP_PUSH;
-        request_hdr->count  = sizeof(request_cmd_entry.iop_push_payload);
-        request_hdr->state  = AMC_PROXY_REQUEST_CMD_NEW;
-        request_hdr->cid    = cmd->cmd_cid;
-
-        request_cmd_entry.iop_push_payload.req_type  = iop_push->type;
-        request_cmd_entry.iop_push_payload.address   = iop_push->address;
-        request_cmd_entry.iop_push_payload.len       = iop_push->length;
-        request_cmd_entry.iop_push_payload.offset    = iop_push->offset;
-        request_cmd_entry.iop_push_payload.dop       = iop_push->dop;
-
-        ret = amc_ctxt->inst.fw_if_handle->write(
-            amc_ctxt->inst.fw_if_handle,
-            0,
-            (uint8_t*)&(request_cmd_entry),
-            sizeof(request_cmd_entry),
-            0
-        );
-
-        if (ret == FW_IF_ERRORS_NONE) {
-            mutex_lock(&(amc_ctxt->inst.lock));
-            list_add_tail(&(cmd->cmd_list), &(amc_ctxt->inst.submitted_cmds));
-            mutex_unlock(&(amc_ctxt->inst.lock));
-        } else {
-            PR_ERR("FW_IF write request failed; %d", ret);
-            ret = -EIO;
-        }
-    }
-    return ret;
-}
-
 /*
  * Generate eeprom read/write request
  */
@@ -1805,24 +1708,6 @@ int amc_proxy_get_response_peek_poke(struct amc_proxy_cmd_struct *cmd)
 {
         struct amc_proxy_list_entry *amc_ctxt = NULL;
         int ret = -EPERM;
-
-        if (!cmd) {
-                return(-EINVAL);
-        }
-
-        amc_ctxt = amc_proxy_find_matching_proxy_instance(cmd->cmd_fw_if_gcq);
-        if (amc_ctxt && amc_ctxt->inst.initialised)
-                ret = amc_result_to_linux_errno(cmd->cmd_response_code);
-
-        return ret;
-}
-
-int amc_proxy_get_response_iop_push(struct amc_proxy_cmd_struct *cmd)
-{
-        struct amc_proxy_list_entry *amc_ctxt = NULL;
-        int ret = -EPERM;
-
-        printk("amc_proxy_get_response_iop_push");
 
         if (!cmd) {
                 return(-EINVAL);

--- a/sw/AMI/driver/amc_proxy.h
+++ b/sw/AMI/driver/amc_proxy.h
@@ -21,8 +21,6 @@
 /*****************************************************************************/
 #define AMC_PROXY_REQUEST_SIZE          (512)
 #define AMC_PROXY_RESPONSE_SIZE         (16)
-#define AMC_TRIGGERED_COMMAND_ID        (0xF00D)
-
 
 /*****************************************************************************/
 /* Typedefs                                                                  */
@@ -33,11 +31,10 @@
  * @proxy_id: the associated proxy id.
  * @event_id: the event that cause the callback to be invoked.
  * @arg: void ptr containing the proxy command used to raise request.
- * @ctxt: void ptr containing the amc control context ptr.
  *
  * Return: errno or success code.
  */
-typedef int (amc_proxy_event_callback)(uint8_t proxy_id, uint8_t event_id, void* arg, void* ctxt);
+typedef int (amc_proxy_event_callback)(uint8_t proxy_id, uint8_t event_id, void* arg);
 
 
 /*****************************************************************************/
@@ -206,14 +203,6 @@ struct amc_proxy_ami_peek_poke {
     uint64_t address;
     uint32_t length;
     uint32_t offset;
-};
-
-struct amc_proxy_ami_iop_push {
-    enum amc_proxy_cmd_rw_request type;
-    uint64_t address;
-    uint32_t length;
-    uint32_t offset;
-    bool     dop;
 };
 
 /**
@@ -423,11 +412,16 @@ int amc_proxy_request_partition_copy(struct amc_proxy_cmd_struct *cmd,
 int amc_proxy_request_heartbeat(struct amc_proxy_cmd_struct *cmd,
                                 struct amc_proxy_hearbeat_request *heartbeat);
 
+/**
+ * amc_proxy_request_peek_poke() - peek/poke request
+ *
+ * @cmd: the proxy command structure
+ * @peek_poke: a structure populated with the peek/poke request
+ *
+ * Return: The errno return code
+ */
 int amc_proxy_request_peek_poke(struct amc_proxy_cmd_struct *cmd,
                                 struct amc_proxy_ami_peek_poke *peek_poke);
-
-int amc_proxy_request_iop_push(struct amc_proxy_cmd_struct *cmd,
-                               struct amc_proxy_ami_iop_push *iop_push);
 
 /**
  * amc_proxy_request_eeprom_read_write() - eeprom read/write request
@@ -535,9 +529,14 @@ int amc_proxy_get_response_heartbeat(struct amc_proxy_cmd_struct *cmd,
  */
 int amc_proxy_get_response_eeprom_read_write(struct amc_proxy_cmd_struct *cmd);
 
+/**
+ * amc_proxy_get_response_peek_poke() - retrieve the peek/poke response
+ *
+ * @cmd: the proxy command structure
+ *
+ * Return: The errno return code
+ */
 int amc_proxy_get_response_peek_poke(struct amc_proxy_cmd_struct *cmd);
-
-int amc_proxy_get_response_iop_push(struct amc_proxy_cmd_struct *cmd);
 
 /**
  * amc_proxy_get_response_module_read_write() - retrieve the module read/write response

--- a/sw/AMI/driver/ami_amc_control.c
+++ b/sw/AMI/driver/ami_amc_control.c
@@ -17,15 +17,9 @@
 #include "ami_program.h"
 #include "ami_eeprom.h"
 #include "ami_peekpoke.h"
-#include "ami_iop_push.h"
 #include "ami_log.h"
 #include "ami_module.h"
 #include "ami_driver_version.h"
-
-extern uint32_t *global_iop_ack_table;
-extern uint32_t global_iop_ack_table_size;
-extern atomic_t iop_ack_cnt_atomic;
-extern wait_queue_head_t wait_iop_q;
 
 /*****************************************************************************/
 /* Local Varaiables                                                          */
@@ -453,10 +447,9 @@ static int remove_gcq_cid(struct amc_control_ctxt *amc_ctrl_ctxt, uint16_t id)
  *
  * Return: errno or success code.
  */
-static int amc_proxy_callback(uint8_t proxy_id, uint8_t event_id, void*arg, void*ctxt)
+static int amc_proxy_callback(uint8_t proxy_id, uint8_t event_id, void*arg)
 {
     struct amc_proxy_cmd_struct *amc_proxy_cmd = NULL;
-    struct amc_control_ctxt *amc_ctrl_ctxt = NULL;
     struct completion *req_complete = NULL;
     int ret = 0;
 
@@ -464,10 +457,6 @@ static int amc_proxy_callback(uint8_t proxy_id, uint8_t event_id, void*arg, void
         return -EINVAL;
 
     amc_proxy_cmd = (struct amc_proxy_cmd_struct*)arg;
-
-    // ctxt is only useful for AMC_PROXY_EVENT_TRIGGERED_BY_AMC
-    if (ctxt != NULL)
-        amc_ctrl_ctxt = (struct amc_control_ctxt*)ctxt;
 
     if (amc_proxy_cmd->cmd_opcode == AMC_CMD_ID_HEARTBEAT)
         req_complete = &amc_proxy_cmd->cmd_complete_heartbeat;
@@ -484,35 +473,6 @@ static int amc_proxy_callback(uint8_t proxy_id, uint8_t event_id, void*arg, void
             /* Signal condvar to unblock & fetch the failed response */
             complete(req_complete);
             amc_proxy_cmd->timed_out = true;
-            break;
-
-        case AMC_PROXY_EVENT_TRIGGERED_BY_AMC:
-            PR_INFO("Got cmd from AMC with payload %llx atomic %d", amc_proxy_cmd->cmd_response, atomic_read(&iop_ack_cnt_atomic));
-            if (amc_ctrl_ctxt != NULL) {
-                int i = 0;
-                // number of IOP ack is an offset on the command id
-                uint32_t iopAckNb = amc_proxy_cmd->cmd_cid - AMC_TRIGGERED_COMMAND_ID;
-                uint32_t* iopAck;
-                iopAck = kzalloc(iopAckNb * sizeof(uint32_t), GFP_KERNEL);
-                global_iop_ack_table = iopAck;
-                global_iop_ack_table_size = iopAckNb;
-                PR_INFO("Reading %d words @ offset %x", iopAckNb, AMC_DATA_ADDR_OFF2);
-                memcpy_gcq_payload_from_device(amc_ctrl_ctxt, AMC_DATA_ADDR_OFF2, iopAck, iopAckNb * sizeof(uint32_t));
-                for (i = 0; i < iopAckNb; i++) {
-                    PR_INFO("iopAck[%d] = %x", i, iopAck[i]);
-                }
-                atomic_add(iopAckNb, &iop_ack_cnt_atomic);
-                PR_INFO("Just add %d to iop_ack_cnt_atomic to %d", iopAckNb, atomic_read(&iop_ack_cnt_atomic));
-                // acknowledge that data have been read (even if it has not been)
-                iowrite32(0xDEADF00D, amc_ctrl_ctxt->gcq_payload_base_virt_addr + AMC_DATA_ADDR_OFF2);
-                // signaling ami_top that waiting reader can be woken
-                wake_up(&wait_iop_q);
-
-                kfree(iopAck);
-            } else {
-                PR_INFO("Got cmd from AMC but no amc_control_ctxt");
-            }
-            kfree(amc_proxy_cmd);
             break;
 
         default:
@@ -831,10 +791,6 @@ static enum amc_cmd_id get_cmd_command_id(enum gcq_submit_cmd_req cmd_req)
 
     case GCQ_SUBMIT_CMD_PEEKPOKE:
         id = AMC_CMD_ID_PEEKPOKE;
-        break;
-
-    case GCQ_SUBMIT_CMD_IOP_PUSH:
-        id = AMC_CMD_ID_IOP_PUSH;
         break;
 
     case GCQ_SUBMIT_CMD_MODULE_READ_WRITE:
@@ -1277,7 +1233,6 @@ int submit_gcq_command(struct amc_control_ctxt    *amc_ctrl_ctxt,
     case AMC_CMD_ID_HEARTBEAT:
     case AMC_CMD_ID_EEPROM_READ_WRITE:
     case AMC_CMD_ID_PEEKPOKE:
-    case AMC_CMD_ID_IOP_PUSH:
     case AMC_CMD_ID_MODULE_READ_WRITE:
         if (!data_buf) {
             ret = -EINVAL;
@@ -1432,7 +1387,6 @@ int submit_gcq_command(struct amc_control_ctxt    *amc_ctrl_ctxt,
     case AMC_CMD_ID_EEPROM_READ_WRITE:
     case AMC_CMD_ID_MODULE_READ_WRITE:
     case AMC_CMD_ID_PEEKPOKE:
-    case AMC_CMD_ID_IOP_PUSH:
     {
         int req_type = MAX_AMC_PROXY_CMD_RW_REQUEST;
 
@@ -1464,9 +1418,6 @@ int submit_gcq_command(struct amc_control_ctxt    *amc_ctrl_ctxt,
 
         case AMC_CMD_ID_PEEKPOKE:
             req_type = PEEKPOKE_GET_TYPE(flags);
-            break;
-        case AMC_CMD_ID_IOP_PUSH:
-            req_type = IOP_PUSH_GET_TYPE(flags);
             break;
 
         case AMC_CMD_ID_MODULE_READ_WRITE:
@@ -1601,20 +1552,6 @@ int submit_gcq_command(struct amc_control_ctxt    *amc_ctrl_ctxt,
         peek_poke_req.offset  = PEEKPOKE_GET_OFFSET(flags);
 
         ret = amc_proxy_request_peek_poke(amc_proxy_cmd, &peek_poke_req);
-        break;
-    }
-
-    case AMC_CMD_ID_IOP_PUSH:
-    {
-        struct amc_proxy_ami_iop_push iop_push_req = { 0 };
-
-        iop_push_req.address = payload_address;
-        iop_push_req.length  = payload_size;
-        iop_push_req.type    = IOP_PUSH_GET_TYPE(flags);
-        iop_push_req.offset  = IOP_PUSH_GET_OFFSET(flags);
-        iop_push_req.dop     = IOP_PUSH_GET_DOP(flags);
-
-        ret = amc_proxy_request_iop_push(amc_proxy_cmd, &iop_push_req);
         break;
     }
 
@@ -1759,15 +1696,6 @@ int submit_gcq_command(struct amc_control_ctxt    *amc_ctrl_ctxt,
                 memcpy_gcq_payload_from_device(amc_ctrl_ctxt, payload_address, data_buf, data_size);
             }
         }
-        break;
-    }
-
-    case AMC_CMD_ID_IOP_PUSH:
-    {
-        ret = amc_proxy_get_response_iop_push(amc_proxy_cmd);
-        if (!ret)
-            if (IOP_PUSH_GET_TYPE(flags) == AMC_PROXY_CMD_RW_REQUEST_READ)
-                memcpy_gcq_payload_from_device(amc_ctrl_ctxt, payload_address, data_buf, data_size);
         break;
     }
 

--- a/sw/AMI/driver/ami_amc_control.h
+++ b/sw/AMI/driver/ami_amc_control.h
@@ -174,7 +174,6 @@ enum gcq_submit_cmd_req {
     GCQ_SUBMIT_CMD_MODULE_READ_WRITE            = 0x90,
     GCQ_SUBMIT_CMD_DEBUG_VERBOSITY              = 0x91,
     GCQ_SUBMIT_CMD_PEEKPOKE                     = 0xDEC,
-    GCQ_SUBMIT_CMD_IOP_PUSH                     = 0xCAB,
 };
 
 /**
@@ -376,7 +375,6 @@ enum amc_cmd_id {
     AMC_CMD_ID_MODULE_READ_WRITE,
     AMC_CMD_ID_DEBUG_VERBOSITY,
     AMC_CMD_ID_PEEKPOKE,
-    AMC_CMD_ID_IOP_PUSH,
 
     AMC_CMD_ID_MAX
 };

--- a/sw/AMI/driver/ami_iop_push.h
+++ b/sw/AMI/driver/ami_iop_push.h
@@ -11,20 +11,6 @@
 #include "ami_top.h"
 #include "ami_amc_control.h"
 
-#define    IOP_PUSH_TYPE_POS    (0)
-#define    IOP_PUSH_TYPE_MASK   (0x01)
-#define    IOP_PUSH_OFFSET_POS  (8)
-#define    IOP_PUSH_OFFSET_DOP  (7)
-#define    IOP_PUSH_OFFSET_MASK (0xFFFF)
-
-#define IOP_PUSH_GET_OFFSET(data)   ((data >> IOP_PUSH_OFFSET_POS) & IOP_PUSH_OFFSET_MASK)
-#define IOP_PUSH_GET_TYPE(data)     ((data >> IOP_PUSH_TYPE_POS) & IOP_PUSH_TYPE_MASK)
-#define IOP_PUSH_GET_DOP(data)      ((data >> IOP_PUSH_OFFSET_DOP) & IOP_PUSH_TYPE_MASK)
-
-#define IOP_PUSH_SET_OFFSET(data)   ((data & IOP_PUSH_OFFSET_MASK) << IOP_PUSH_OFFSET_POS)
-#define IOP_PUSH_SET_DOP(data)      ((data & IOP_PUSH_TYPE_MASK) << IOP_PUSH_OFFSET_DOP)
-#define IOP_PUSH_SET_TYPE(data)     ((data & IOP_PUSH_TYPE_MASK) << IOP_PUSH_TYPE_POS)
-
 int iop_push(
     struct amc_control_ctxt *amc_ctrl_ctxt,
     uint8_t *buf,

--- a/sw/AMI/driver/ami_top.c
+++ b/sw/AMI/driver/ami_top.c
@@ -1044,7 +1044,7 @@ int __init vmc_entry(void)
 
     ret = register_proc_file();
     if (ret)
-            goto fail;
+        goto fail;
 
     /* Register the device driver with the kernel */
     ret = register_driver_kernel();


### PR DESCRIPTION
from AMI to AMC and AMC to AMI
a few indentation and compilation warning cleanup