### PR TITLE
[FEAT] removing access to hardware discovery + check in driver initialization

### DIFF
--- a/sw/AMI/driver/ami_amc_control.c
+++ b/sw/AMI/driver/ami_amc_control.c
@@ -20,6 +20,7 @@
 #include "ami_log.h"
 #include "ami_module.h"
 #include "ami_driver_version.h"
+#include "ami_vsec.h"
 
 /*****************************************************************************/
 /* Local Varaiables                                                          */
@@ -56,7 +57,6 @@ static DEFINE_XARRAY_ALLOC(cid_xarray);
 
 /* Number of permitted failures before raising a fatal event */
 #define HEARTBEAT_FAIL_THRESHOLD                (3)
-
 
 /*****************************************************************************/
 /* Private functions                                                         */
@@ -857,13 +857,10 @@ static int map_amc_endpoints(struct pci_dev        *dev,
     pf_dev->pcie_config->header->bar[PCIE_BAR0].requested = true;
 
     /* Map the GCQ IP Region */
-    // bar num = 0
-    // bar len = 0x1000
-    // start address = 0x1010000
     amc_ctrl_ctxt->gcq_base_virt_addr = pci_iomap_range(amc_ctrl_ctxt->pcie_dev,
-                                0x0,
-                                0x1010000,
-                                0x1000);
+        GCQ_IP_BAR_NUM,
+        GCQ_IP_START_ADDR,
+        GCQ_IP_BAR_LEN);
 
     if (!(amc_ctrl_ctxt->gcq_base_virt_addr)) {
         AMI_ERR(amc_ctrl_ctxt, "Could not map GCQ IP into virtual memory");
@@ -872,13 +869,10 @@ static int map_amc_endpoints(struct pci_dev        *dev,
     }
 
     /* Map the GCQ Payload Region */
-    // bar num = 0
-    // bar len = 0x8000000 (128M)
-    // start address = 0x8000000
     amc_ctrl_ctxt->gcq_payload_base_virt_addr = pci_iomap_range(amc_ctrl_ctxt->pcie_dev,
-                                    0x0,
-                                    0x8000000,
-                                    0x8000000);
+        GCQ_PAYLOAD_BAR_NUM,
+        GCQ_PAYLOAD_START_ADDR,
+        GCQ_PAYLOAD_BAR_LEN);
 
     if (!(amc_ctrl_ctxt->gcq_payload_base_virt_addr)) {
         AMI_ERR(amc_ctrl_ctxt, "Could not map GCQ payload into virtual memory");

--- a/sw/AMI/driver/ami_amc_control.c
+++ b/sw/AMI/driver/ami_amc_control.c
@@ -857,6 +857,9 @@ static int map_amc_endpoints(struct pci_dev        *dev,
     pf_dev->pcie_config->header->bar[PCIE_BAR0].requested = true;
 
     /* Map the GCQ IP Region */
+    // bar num = 0
+    // bar len = 0x1000
+    // start address = 0x1010000
     amc_ctrl_ctxt->gcq_base_virt_addr = pci_iomap_range(amc_ctrl_ctxt->pcie_dev,
                                 0x0,
                                 0x1010000,
@@ -868,17 +871,10 @@ static int map_amc_endpoints(struct pci_dev        *dev,
         goto fail;
     }
 
-    // AMI_VDBG(amc_ctrl_ctxt,
-    //      "\t- gcq_start_phy          : 0x%llx",
-    //      ep_gcq.start_addr);
-    // AMI_VDBG(amc_ctrl_ctxt,
-    //      "\t- gcq_len                : 0x%llx",
-    //      ep_gcq.bar_len);
-    // AMI_VDBG(amc_ctrl_ctxt,
-    //      "\t- gcq_bar_num            : 0x%x",
-    //      ep_gcq.bar_num);
-
     /* Map the GCQ Payload Region */
+    // bar num = 0
+    // bar len = 0x8000000 (128M)
+    // start address = 0x8000000
     amc_ctrl_ctxt->gcq_payload_base_virt_addr = pci_iomap_range(amc_ctrl_ctxt->pcie_dev,
                                     0x0,
                                     0x8000000,
@@ -889,21 +885,6 @@ static int map_amc_endpoints(struct pci_dev        *dev,
         ret = -EIO;
         goto fail;
     }
-
-    // /* Map the Ring Buffer base address */
-    // AMI_VDBG(amc_ctrl_ctxt, "Successfully mapped GCQ payload");
-    // AMI_VDBG(amc_ctrl_ctxt,
-    //      "\t- gcq_payload_start_phy          : 0x%llx",
-    //      ep_gcq_payload.start_addr);
-    // AMI_VDBG(amc_ctrl_ctxt,
-    //      "\t- gcq_payload_len                : 0x%llx",
-    //      ep_gcq_payload.bar_len);
-    // AMI_VDBG(amc_ctrl_ctxt,
-    //      "\t- gcq_payload_bar_num            : 0x%x",
-    //      ep_gcq_payload.bar_num);
-    // AMI_VDBG(amc_ctrl_ctxt,
-    //      "\t- GCQ payload virtual addr       : 0x%p",
-    //      amc_ctrl_ctxt->gcq_payload_base_virt_addr);
 
     AMI_VDBG(amc_ctrl_ctxt, "Successfully mapped GCQ endpoints");
     return SUCCESS;

--- a/sw/AMI/driver/ami_amc_control.c
+++ b/sw/AMI/driver/ami_amc_control.c
@@ -354,9 +354,8 @@ static int start_gcq_services(struct amc_control_ctxt *amc_ctrl_ctxt)
         ret = -ENODEV;
         goto fail;
     }
-
     amc_ctrl_ctxt->gcq_ring_buf_base_virt_addr = amc_ctrl_ctxt->gcq_payload_base_virt_addr +
-                             amc_ctrl_ctxt->amc_shared_mem.ring_buffer.ring_buffer_off;
+                                                 amc_ctrl_ctxt->amc_shared_mem.ring_buffer.ring_buffer_off;
 
     AMI_VDBG(amc_ctrl_ctxt,
          "\t- GCQ ring buffer virtual addr   : 0x%p",
@@ -859,9 +858,9 @@ static int map_amc_endpoints(struct pci_dev        *dev,
 
     /* Map the GCQ IP Region */
     amc_ctrl_ctxt->gcq_base_virt_addr = pci_iomap_range(amc_ctrl_ctxt->pcie_dev,
-                                ep_gcq.bar_num,
-                                ep_gcq.start_addr,
-                                ep_gcq.bar_len);
+                                0x0,
+                                0x1010000,
+                                0x1000);
 
     if (!(amc_ctrl_ctxt->gcq_base_virt_addr)) {
         AMI_ERR(amc_ctrl_ctxt, "Could not map GCQ IP into virtual memory");
@@ -869,21 +868,21 @@ static int map_amc_endpoints(struct pci_dev        *dev,
         goto fail;
     }
 
-    AMI_VDBG(amc_ctrl_ctxt,
-         "\t- gcq_start_phy          : 0x%llx",
-         ep_gcq.start_addr);
-    AMI_VDBG(amc_ctrl_ctxt,
-         "\t- gcq_len                : 0x%llx",
-         ep_gcq.bar_len);
-    AMI_VDBG(amc_ctrl_ctxt,
-         "\t- gcq_bar_num            : 0x%x",
-         ep_gcq.bar_num);
+    // AMI_VDBG(amc_ctrl_ctxt,
+    //      "\t- gcq_start_phy          : 0x%llx",
+    //      ep_gcq.start_addr);
+    // AMI_VDBG(amc_ctrl_ctxt,
+    //      "\t- gcq_len                : 0x%llx",
+    //      ep_gcq.bar_len);
+    // AMI_VDBG(amc_ctrl_ctxt,
+    //      "\t- gcq_bar_num            : 0x%x",
+    //      ep_gcq.bar_num);
 
     /* Map the GCQ Payload Region */
     amc_ctrl_ctxt->gcq_payload_base_virt_addr = pci_iomap_range(amc_ctrl_ctxt->pcie_dev,
-                                    ep_gcq_payload.bar_num,
-                                    ep_gcq_payload.start_addr,
-                                    ep_gcq_payload.bar_len);
+                                    0x0,
+                                    0x8000000,
+                                    0x8000000);
 
     if (!(amc_ctrl_ctxt->gcq_payload_base_virt_addr)) {
         AMI_ERR(amc_ctrl_ctxt, "Could not map GCQ payload into virtual memory");
@@ -891,20 +890,20 @@ static int map_amc_endpoints(struct pci_dev        *dev,
         goto fail;
     }
 
-    /* Map the Ring Buffer base address */
-    AMI_VDBG(amc_ctrl_ctxt, "Successfully mapped GCQ payload");
-    AMI_VDBG(amc_ctrl_ctxt,
-         "\t- gcq_payload_start_phy          : 0x%llx",
-         ep_gcq_payload.start_addr);
-    AMI_VDBG(amc_ctrl_ctxt,
-         "\t- gcq_payload_len                : 0x%llx",
-         ep_gcq_payload.bar_len);
-    AMI_VDBG(amc_ctrl_ctxt,
-         "\t- gcq_payload_bar_num            : 0x%x",
-         ep_gcq_payload.bar_num);
-    AMI_VDBG(amc_ctrl_ctxt,
-         "\t- GCQ payload virtual addr       : 0x%p",
-         amc_ctrl_ctxt->gcq_payload_base_virt_addr);
+    // /* Map the Ring Buffer base address */
+    // AMI_VDBG(amc_ctrl_ctxt, "Successfully mapped GCQ payload");
+    // AMI_VDBG(amc_ctrl_ctxt,
+    //      "\t- gcq_payload_start_phy          : 0x%llx",
+    //      ep_gcq_payload.start_addr);
+    // AMI_VDBG(amc_ctrl_ctxt,
+    //      "\t- gcq_payload_len                : 0x%llx",
+    //      ep_gcq_payload.bar_len);
+    // AMI_VDBG(amc_ctrl_ctxt,
+    //      "\t- gcq_payload_bar_num            : 0x%x",
+    //      ep_gcq_payload.bar_num);
+    // AMI_VDBG(amc_ctrl_ctxt,
+    //      "\t- GCQ payload virtual addr       : 0x%p",
+    //      amc_ctrl_ctxt->gcq_payload_base_virt_addr);
 
     AMI_VDBG(amc_ctrl_ctxt, "Successfully mapped GCQ endpoints");
     return SUCCESS;

--- a/sw/AMI/driver/ami_pcie.c
+++ b/sw/AMI/driver/ami_pcie.c
@@ -972,7 +972,6 @@ int write_pcie_configuration(struct pci_dev *dev)
 			1,
 			&gpio_reset
 		);
-		printk("ret %x",ret);
 		if (ret) {
 			DEV_ERR(dev, "Failed to clear GPIO reset");
 			goto fail;

--- a/sw/AMI/driver/ami_pcie.c
+++ b/sw/AMI/driver/ami_pcie.c
@@ -963,12 +963,6 @@ int write_pcie_configuration(struct pci_dev *dev)
 	 * Identity event over GCQ will enable the hot reload so we must make
 	 * sure the PMC GPIO is cleared to prevent a reboot.
 	 */
-	printk("dev %x",dev);
-	printk("PCI_GPIO_RESET_BAR %x",PCI_GPIO_RESET_BAR);
-	printk("PCI_GPIO_RESET_OFFSET %x",PCI_GPIO_RESET_OFFSET);
-	printk("&gpio_reset %x",&gpio_reset);
-	printk("ret %x",ret);
-
 	if (PCI_FUNC(dev->devfn) == 0) {
 		DEV_VDBG(dev, "Clearing GPIO reset");
 		ret = write_pcie_bar(

--- a/sw/AMI/driver/ami_pcie.c
+++ b/sw/AMI/driver/ami_pcie.c
@@ -963,6 +963,12 @@ int write_pcie_configuration(struct pci_dev *dev)
 	 * Identity event over GCQ will enable the hot reload so we must make
 	 * sure the PMC GPIO is cleared to prevent a reboot.
 	 */
+	printk("dev %x",dev);
+	printk("PCI_GPIO_RESET_BAR %x",PCI_GPIO_RESET_BAR);
+	printk("PCI_GPIO_RESET_OFFSET %x",PCI_GPIO_RESET_OFFSET);
+	printk("&gpio_reset %x",&gpio_reset);
+	printk("ret %x",ret);
+
 	if (PCI_FUNC(dev->devfn) == 0) {
 		DEV_VDBG(dev, "Clearing GPIO reset");
 		ret = write_pcie_bar(
@@ -972,6 +978,7 @@ int write_pcie_configuration(struct pci_dev *dev)
 			1,
 			&gpio_reset
 		);
+		printk("ret %x",ret);
 		if (ret) {
 			DEV_ERR(dev, "Failed to clear GPIO reset");
 			goto fail;

--- a/sw/AMI/driver/ami_top.c
+++ b/sw/AMI/driver/ami_top.c
@@ -381,7 +381,7 @@ static int create_pf_dev_data(struct pci_dev *dev)
     if (ret)
         goto delete_data;
 
-    // tandem change: Read vendor specific information
+    // tandem change: read directly vendor specific information
     ret = read_vsec(dev, pf_dev->pcie_config->ext_cap->vsec_base_addr, &pf_dev->endpoints);
     if (ret)
         goto delete_data;

--- a/sw/AMI/driver/ami_top.c
+++ b/sw/AMI/driver/ami_top.c
@@ -1017,6 +1017,20 @@ static DRIVER_ATTR_RW(ami_debug_enabled);
 int __init vmc_entry(void)
 {
     int ret = 0;
+    struct pci_dev *dev = NULL;
+    u8 command_register;
+
+    dev = pci_get_device(PCIE_VENDOR_ID, PCIE_DEVICE_ID, NULL);
+    ret = pci_read_config_byte(dev, 0x4, &command_register);
+
+    // Check if Bus Master Enable register is correctly set
+    if (get_pcie_command_master(command_register) != 1) {
+        PR_ERR("BAR0 bus master check failed: Normal between stage 1 and stage 2 programming");
+        return -EIO;
+    }
+
+    // release pci device structure
+    pci_dev_put(dev);
 
     /* Init FAL for GCQ */
     ret = ulFW_IF_GCQ_Init(&fw_if_gcq_init_cfg);

--- a/sw/AMI/driver/ami_top.c
+++ b/sw/AMI/driver/ami_top.c
@@ -1021,11 +1021,11 @@ int __init vmc_entry(void)
     u8 command_register;
 
     dev = pci_get_device(PCIE_VENDOR_ID, PCIE_DEVICE_ID, NULL);
-    ret = pci_read_config_byte(dev, 0x4, &command_register);
+    ret = pci_read_config_byte(dev, PCI_COMMAND, &command_register);
 
     // Check if Bus Master Enable register is correctly set
     if (get_pcie_command_master(command_register) != 1) {
-        PR_ERR("BAR0 bus master check failed: Normal between stage 1 and stage 2 programming");
+        PR_ERR("BAR0 bus master check failed: Expected if between stage 1 and stage 2 programming");
         return -EIO;
     }
 

--- a/sw/AMI/driver/ami_top.c
+++ b/sw/AMI/driver/ami_top.c
@@ -382,17 +382,10 @@ static int create_pf_dev_data(struct pci_dev *dev)
     if (ret)
         goto delete_data;
 
-    /* Read vendor specific information */
-    if (pf_dev->pcie_config->ext_cap->vsec_base_addr_found) {
-        ret = read_vsec(dev,
-                pf_dev->pcie_config->ext_cap->vsec_base_addr,
-                &pf_dev->endpoints);
-        if (ret)
-            goto delete_data;
-    } else {
-        ret = -EINVAL;
+    // tandem change: Read vendor specific information
+    ret = read_vsec(dev, pf_dev->pcie_config->ext_cap->vsec_base_addr, &pf_dev->endpoints);
+    if (ret)
         goto delete_data;
-    }
 
     /* AMC Setup */
     /*

--- a/sw/AMI/driver/ami_vsec.c
+++ b/sw/AMI/driver/ami_vsec.c
@@ -82,7 +82,6 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	bool end_of_table = false;
 	uint32_t table_length = 0, table_entry_size = 0;
 	uint8_t ep_bar_num = 0;
-	// void * __iomem hw_discovery_virt_addr = NULL;
 	uint8_t pcie_function_num = 0;
 
 	if (!dev || !endpoints)
@@ -99,60 +98,6 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 		ret = -ENOMEM;
 		goto fail;
 	}
-
-	/*
-	 * Additional List of Features (ALF) VSEC
-	 *
-	 *  ----------------------------------------------------------------------
-	 * | Next Cap [31:20] | Cap Version [19:16] | PCIe Extended Cap ID [15:0] |
-	 *  ----------------------------------------------------------------------
-	 * | VSEC Len [31:20] | VSEC Rev [19:16]    | VSEC ID [15:0]              |
-	 *  ----------------------------------------------------------------------
-	 * |             Low Address [31:4]         | Rsvd [3] | Bar Index [2:0]  |
-	 *  ----------------------------------------------------------------------
-	 * |                    High Address [31:0] effective [63:32]             |
-	 *  ----------------------------------------------------------------------
-	 */
-	// ret = pci_read_config_dword(dev, vsec_base_addr + ALF_VSEC_HDR_OFFSET,
-	// 	&read_buf);
-	// if (ret) {
-	// 	ret = -EIO;
-	// 	goto fail;
-	// }
-	// vsec_len = (read_buf >> ALF_VSEC_LEN_OFFSET) & ALF_VSEC_LEN_MASK;
-	// DEV_VDBG(dev, "vsec len : 0x%X", vsec_len);
-
-	// ret = pci_read_config_dword(dev, vsec_base_addr + ALF_VSEC_FIELD1_OFFSET,
-	// 	&read_buf);
-	// if (ret) {
-	// 	ret = -EIO;
-	// 	goto fail;
-	// }
-
-	// (*endpoints)->hw_discovery.bar_num = (read_buf >> ALF_VSEC_BAR_IDX_OFFSET) & ALF_VSEC_BAR_IDX_MASK;
-	// (*endpoints)->hw_discovery.start_addr = (read_buf >> ALF_VSEC_OFF_LOW_OFFSET) & ALF_VSEC_OFF_LOW_MASK;
-
-	// if (vsec_len == ALF_VSEC_HIGH_OFFSET_IMPLEMENTED) {
-	// 	/* Read the offset high register */
-	// 	ret = pci_read_config_dword(dev,
-	// 		vsec_base_addr + ALF_VSEC_FIELD2_OFFSET, &read_buf);
-	// 	if (ret) {
-	// 		ret = -EIO;
-	// 		goto fail;
-	// 	}
-
-	// 	(*endpoints)->hw_discovery.start_addr |= ((uint64_t)((read_buf >> ALF_VSEC_OFF_HIGH_OFFSET) &
-	// 		ALF_VSEC_OFF_HIGH_MASK) << ALF_VSEC_OFF_LOW_LEN);
-	// }
-
-	// (*endpoints)->hw_discovery.bar_len = XILINX_ENDPOINT_BAR_LEN_HW_DISCOVERY;
-	// (*endpoints)->hw_discovery.end_addr = (*endpoints)->hw_discovery.start_addr +
-	// 	(*endpoints)->hw_discovery.bar_len - 1;
-
-	// strcpy((*endpoints)->hw_discovery.name,
-	// 	XILINX_ENDPOINT_NAME_HW_DISCOVERY_PF0);
-
-	// print_endpoint_info(dev, (*endpoints)->hw_discovery);
 
 	/*
 	 * Traverse the Xilinx Capabilities
@@ -184,59 +129,8 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	 *  0x40 - 64 byte entry size
 	 *  0x80 - 128 byte entry size
 	 */
-
-	/* Map the Header Registers and Table Format */
-	// hw_discovery_virt_addr = pci_iomap_range(dev,
-	// 		(*endpoints)->hw_discovery.bar_num,
-	// 		(*endpoints)->hw_discovery.start_addr,
-	// 		XILINX_HW_DISCOVERY_TABLE_OFFSET);
-
-	// if (!hw_discovery_virt_addr) {
-	// 	DEV_ERR(dev, "Failed to map bar_layout into memory");
-	// 	ret = -EIO;
-	// 	goto fail;
-	// }
-
-	// DEV_VDBG(dev, "HW discovery Virt Addr : %p , Device Addr : %llx",
-	// 	hw_discovery_virt_addr,
-	// 	(*endpoints)->hw_discovery.start_addr);
-
-	// /* Calculate the length of all the table entries excluding header */
-	// read_buf = ioread32(hw_discovery_virt_addr + XILINX_HW_DISCOVERY_LEN_OFFSET);
-
-	// table_length = (read_buf & XILINX_HW_DISCOVERY_LEN_MASK) - XILINX_HW_DISCOVERY_TABLE_OFFSET;
-
-	// read_buf = ioread32(hw_discovery_virt_addr + XILINX_HW_DISCOVERY_ENTRY_SIZE_OFFSET);
 	table_length = 0x40;
 	table_entry_size = 0x10;
-
-	// DEV_VDBG(dev, "table_length : 0x%X, table_entry_size : 0x%X",
-	// 	table_length, table_entry_size);
-
-	// /* Do some basic sanity checking */
-	// if ((table_length == ((uint32_t)-1)) ||
-	// 		(table_entry_size > XILINX_HW_DISCOVERY_ENTRY_SIZE_MAX) ||
-	// 		((table_length % table_entry_size) != 0)) {
-	// 	DEV_ERR(dev, "Invalid table size");
-	// 	ret = -EINVAL;
-	// 	goto fail;
-	// }
-
-	// /* Unmap the memory mapped BAR region */
-	// DEV_VDBG(dev, "Unmapping BAR Entry");
-	// pci_iounmap(dev, hw_discovery_virt_addr);
-
-	// /* Map the Table Entry 1 ... n */
-	// hw_discovery_virt_addr = pci_iomap_range(dev,
-	// 		(*endpoints)->hw_discovery.bar_num,
-	// 		(*endpoints)->hw_discovery.start_addr + XILINX_HW_DISCOVERY_TABLE_OFFSET,
-	// 		table_length);
-
-	// if (!hw_discovery_virt_addr) {
-	// 	DEV_ERR(dev, "Failed to map bar table entry into memory");
-	// 	ret = -EIO;
-	// 	goto fail;
-	// }
 
 	/*
 	 *                                         Table Entry
@@ -343,10 +237,6 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 			break;
 		}
 	}
-
-	// DEV_VDBG(dev, "Unmapping HW discovery BAR memory");
-	// pci_iounmap(dev, hw_discovery_virt_addr);
-	// hw_discovery_virt_addr = 0;
 
 	ret = read_logic_uuid(dev, endpoints);
 	if (ret)

--- a/sw/AMI/driver/ami_vsec.c
+++ b/sw/AMI/driver/ami_vsec.c
@@ -28,21 +28,29 @@ int read_logic_uuid(struct pci_dev *dev, endpoints_struct **endpoints)
 		goto fail;
 	}
 
-	ret = pci_request_region(dev, (*endpoints)->uuid0_rom.bar_num, 
+	ret = pci_request_region(dev, (*endpoints)->uuid0_rom.bar_num,
 			PCIE_BAR_NAME[(*endpoints)->uuid0_rom.bar_num]);
 	if (ret) {
-		DEV_ERR(dev, "Could not request %s region (%s)", 
+		DEV_ERR(dev, "Could not request %s region (%s)",
 			PCIE_BAR_NAME[(*endpoints)->uuid0_rom.bar_num],
 			(*endpoints)->uuid0_rom.name);
 		ret = -EIO;
 		goto fail;
 	}
 
-	virt_addr = pci_iomap_range(dev, (*endpoints)->uuid0_rom.bar_num, 
-			(*endpoints)->uuid0_rom.start_addr,
-			(*endpoints)->uuid0_rom.bar_len);
+	printk("uuid0_rom.bar_num %x", (*endpoints)->uuid0_rom.bar_num);
+	printk("uuid0_rom.start_addr %x", (*endpoints)->uuid0_rom.start_addr);
+	printk("uuid0_rom.bar_len %x", (*endpoints)->uuid0_rom.bar_len);
+
+	virt_addr = pci_iomap_range(dev,
+		(*endpoints)->uuid0_rom.bar_num,
+		(*endpoints)->uuid0_rom.start_addr,
+		(*endpoints)->uuid0_rom.bar_len);
+
+	printk("virt_addr %x", virt_addr);
+	printk("dev %x", dev);
 	if (!virt_addr) {
-		DEV_ERR(dev, "Could not map %s endpoint into virtual memory at start address 0x%llX", 
+		DEV_ERR(dev, "Could not map %s endpoint into virtual memory at start address 0x%llX",
 			(*endpoints)->uuid0_rom.name, (*endpoints)->uuid0_rom.start_addr);
 		ret = -EIO;
 		goto release_bar;
@@ -77,14 +85,11 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 {
 	int ret = 0;
 	int i = 0;
-	uint32_t read_buf = 0;
 	bool end_of_table = false;
 	uint32_t table_length = 0, table_entry_size = 0;
-	uint8_t ep_type = 0, ep_bar_num = 0;
-	uint64_t ep_start_addr = 0;
-	void * __iomem hw_discovery_virt_addr = NULL;
+	uint8_t ep_bar_num = 0;
+	// void * __iomem hw_discovery_virt_addr = NULL;
 	uint8_t pcie_function_num = 0;
-	uint16_t vsec_len = 0;
 
 	if (!dev || !endpoints)
 		return -EINVAL;
@@ -114,50 +119,46 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	 * |                    High Address [31:0] effective [63:32]             |
 	 *  ----------------------------------------------------------------------
 	 */
-	ret = pci_read_config_dword(dev, vsec_base_addr + ALF_VSEC_HDR_OFFSET,
-		&read_buf);
-	if (ret) {
-		ret = -EIO;
-		goto fail;
-	}
-	vsec_len = (read_buf >> ALF_VSEC_LEN_OFFSET) & ALF_VSEC_LEN_MASK;
-	DEV_VDBG(dev, "vsec len : 0x%X", vsec_len);
+	// ret = pci_read_config_dword(dev, vsec_base_addr + ALF_VSEC_HDR_OFFSET,
+	// 	&read_buf);
+	// if (ret) {
+	// 	ret = -EIO;
+	// 	goto fail;
+	// }
+	// vsec_len = (read_buf >> ALF_VSEC_LEN_OFFSET) & ALF_VSEC_LEN_MASK;
+	// DEV_VDBG(dev, "vsec len : 0x%X", vsec_len);
 
-	ret = pci_read_config_dword(dev, vsec_base_addr + ALF_VSEC_FIELD1_OFFSET,
-		&read_buf);
-	if (ret) {
-		ret = -EIO;
-		goto fail;
-	}
+	// ret = pci_read_config_dword(dev, vsec_base_addr + ALF_VSEC_FIELD1_OFFSET,
+	// 	&read_buf);
+	// if (ret) {
+	// 	ret = -EIO;
+	// 	goto fail;
+	// }
 
-	(*endpoints)->hw_discovery.bar_num = \
-		(read_buf >> ALF_VSEC_BAR_IDX_OFFSET) & ALF_VSEC_BAR_IDX_MASK;
-	(*endpoints)->hw_discovery.start_addr = \
-		(read_buf >> ALF_VSEC_OFF_LOW_OFFSET) & ALF_VSEC_OFF_LOW_MASK;
+	// (*endpoints)->hw_discovery.bar_num = (read_buf >> ALF_VSEC_BAR_IDX_OFFSET) & ALF_VSEC_BAR_IDX_MASK;
+	// (*endpoints)->hw_discovery.start_addr = (read_buf >> ALF_VSEC_OFF_LOW_OFFSET) & ALF_VSEC_OFF_LOW_MASK;
 
-	if (vsec_len == ALF_VSEC_HIGH_OFFSET_IMPLEMENTED) {
-		/* Read the offset high register */
-		ret = pci_read_config_dword(dev,
-			vsec_base_addr + ALF_VSEC_FIELD2_OFFSET, &read_buf);
-		if (ret) {
-			ret = -EIO;
-			goto fail;
-		}
+	// if (vsec_len == ALF_VSEC_HIGH_OFFSET_IMPLEMENTED) {
+	// 	/* Read the offset high register */
+	// 	ret = pci_read_config_dword(dev,
+	// 		vsec_base_addr + ALF_VSEC_FIELD2_OFFSET, &read_buf);
+	// 	if (ret) {
+	// 		ret = -EIO;
+	// 		goto fail;
+	// 	}
 
-		(*endpoints)->hw_discovery.start_addr |= \
-			((uint64_t)((read_buf >> ALF_VSEC_OFF_HIGH_OFFSET) &
-			ALF_VSEC_OFF_HIGH_MASK) << ALF_VSEC_OFF_LOW_LEN);
-	}
+	// 	(*endpoints)->hw_discovery.start_addr |= ((uint64_t)((read_buf >> ALF_VSEC_OFF_HIGH_OFFSET) &
+	// 		ALF_VSEC_OFF_HIGH_MASK) << ALF_VSEC_OFF_LOW_LEN);
+	// }
 
-	(*endpoints)->hw_discovery.bar_len = XILINX_ENDPOINT_BAR_LEN_HW_DISCOVERY;
-	(*endpoints)->hw_discovery.end_addr = \
-		(*endpoints)->hw_discovery.start_addr +
-		(*endpoints)->hw_discovery.bar_len - 1;
+	// (*endpoints)->hw_discovery.bar_len = XILINX_ENDPOINT_BAR_LEN_HW_DISCOVERY;
+	// (*endpoints)->hw_discovery.end_addr = (*endpoints)->hw_discovery.start_addr +
+	// 	(*endpoints)->hw_discovery.bar_len - 1;
 
-	strcpy((*endpoints)->hw_discovery.name,
-		XILINX_ENDPOINT_NAME_HW_DISCOVERY_PF0);
+	// strcpy((*endpoints)->hw_discovery.name,
+	// 	XILINX_ENDPOINT_NAME_HW_DISCOVERY_PF0);
 
-	print_endpoint_info(dev, (*endpoints)->hw_discovery);
+	// print_endpoint_info(dev, (*endpoints)->hw_discovery);
 
 	/*
 	 * Traverse the Xilinx Capabilities
@@ -191,61 +192,57 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	 */
 
 	/* Map the Header Registers and Table Format */
-	hw_discovery_virt_addr = pci_iomap_range(dev,
-			(*endpoints)->hw_discovery.bar_num,
-			(*endpoints)->hw_discovery.start_addr,
-			XILINX_HW_DISCOVERY_TABLE_OFFSET);
+	// hw_discovery_virt_addr = pci_iomap_range(dev,
+	// 		(*endpoints)->hw_discovery.bar_num,
+	// 		(*endpoints)->hw_discovery.start_addr,
+	// 		XILINX_HW_DISCOVERY_TABLE_OFFSET);
 
-	if (!hw_discovery_virt_addr) {
-		DEV_ERR(dev, "Failed to map bar_layout into memory");
-		ret = -EIO;
-		goto fail;
-	}
+	// if (!hw_discovery_virt_addr) {
+	// 	DEV_ERR(dev, "Failed to map bar_layout into memory");
+	// 	ret = -EIO;
+	// 	goto fail;
+	// }
 
-	DEV_VDBG(dev, "HW discovery Virt Addr : %p , Device Addr : %llx",
-		hw_discovery_virt_addr,
-		(*endpoints)->hw_discovery.start_addr);
+	// DEV_VDBG(dev, "HW discovery Virt Addr : %p , Device Addr : %llx",
+	// 	hw_discovery_virt_addr,
+	// 	(*endpoints)->hw_discovery.start_addr);
 
-	/* Calculate the length of all the table entries excluding header */
-	read_buf = ioread32(hw_discovery_virt_addr + \
-		XILINX_HW_DISCOVERY_LEN_OFFSET);
+	// /* Calculate the length of all the table entries excluding header */
+	// read_buf = ioread32(hw_discovery_virt_addr + XILINX_HW_DISCOVERY_LEN_OFFSET);
 
-	table_length = (read_buf & XILINX_HW_DISCOVERY_LEN_MASK) - \
-		XILINX_HW_DISCOVERY_TABLE_OFFSET;
+	// table_length = (read_buf & XILINX_HW_DISCOVERY_LEN_MASK) - XILINX_HW_DISCOVERY_TABLE_OFFSET;
 
-	read_buf = ioread32(hw_discovery_virt_addr + \
-		XILINX_HW_DISCOVERY_ENTRY_SIZE_OFFSET);
+	// read_buf = ioread32(hw_discovery_virt_addr + XILINX_HW_DISCOVERY_ENTRY_SIZE_OFFSET);
+	table_length = 0x40;
+	table_entry_size = 0x10;
 
-	table_entry_size = read_buf & XILINX_HW_DISCOVERY_ENTRY_SIZE_MASK;
+	// DEV_VDBG(dev, "table_length : 0x%X, table_entry_size : 0x%X",
+	// 	table_length, table_entry_size);
 
-	DEV_VDBG(dev, "table_length : 0x%X, table_entry_size : 0x%X",
-		table_length, table_entry_size);
-	
-	/* Do some basic sanity checking */
-	if ((table_length == ((uint32_t)-1)) ||
-			(table_entry_size > XILINX_HW_DISCOVERY_ENTRY_SIZE_MAX) ||
-			((table_length % table_entry_size) != 0)) {
-		DEV_ERR(dev, "Invalid table size");
-		ret = -EINVAL;
-		goto fail;
-	}
+	// /* Do some basic sanity checking */
+	// if ((table_length == ((uint32_t)-1)) ||
+	// 		(table_entry_size > XILINX_HW_DISCOVERY_ENTRY_SIZE_MAX) ||
+	// 		((table_length % table_entry_size) != 0)) {
+	// 	DEV_ERR(dev, "Invalid table size");
+	// 	ret = -EINVAL;
+	// 	goto fail;
+	// }
 
-	/* Unmap the memory mapped BAR region */
-	DEV_VDBG(dev, "Unmapping BAR Entry");
-	pci_iounmap(dev, hw_discovery_virt_addr);
+	// /* Unmap the memory mapped BAR region */
+	// DEV_VDBG(dev, "Unmapping BAR Entry");
+	// pci_iounmap(dev, hw_discovery_virt_addr);
 
-	/* Map the Table Entry 1 ... n */
-	hw_discovery_virt_addr = pci_iomap_range(dev,
-			(*endpoints)->hw_discovery.bar_num,
-			(*endpoints)->hw_discovery.start_addr + \
-			XILINX_HW_DISCOVERY_TABLE_OFFSET,
-			table_length);
+	// /* Map the Table Entry 1 ... n */
+	// hw_discovery_virt_addr = pci_iomap_range(dev,
+	// 		(*endpoints)->hw_discovery.bar_num,
+	// 		(*endpoints)->hw_discovery.start_addr + XILINX_HW_DISCOVERY_TABLE_OFFSET,
+	// 		table_length);
 
-	if (!hw_discovery_virt_addr) {
-		DEV_ERR(dev, "Failed to map bar table entry into memory");
-		ret = -EIO;
-		goto fail;
-	}
+	// if (!hw_discovery_virt_addr) {
+	// 	DEV_ERR(dev, "Failed to map bar table entry into memory");
+	// 	ret = -EIO;
+	// 	goto fail;
+	// }
 
 	/*
 	 *                                         Table Entry
@@ -260,44 +257,19 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	 *     |                                Rsvd[31:0]                                               |
 	 *      -----------------------------------------------------------------------------------------
 	 */
+	int ep_type[3]= {0x50,0x54,0x55};
+	int ep_start_addr[3] = {0x1001000, 0x1010000,0x8000000};
+	int index = 0;
 
 	/* Traverse all the table entry */
 	for (i = 0; i < table_length; i += table_entry_size) {
 		if (end_of_table)
 			break;
 
-		DEV_VDBG(dev, "Table entry device base addr : 0x%llX (virt addr = %p)",
-			(*endpoints)->hw_discovery.start_addr +
-			XILINX_HW_DISCOVERY_TABLE_OFFSET + i,
-			hw_discovery_virt_addr + i);
 
-		read_buf = ioread32(hw_discovery_virt_addr + i +
-			XILINX_HW_DISCOVERY_TABLE_ENTRY_ROW_0_OFFSET);
+		ep_bar_num  = 0x0; /* BAR Num where the target aperture is located */
 
-		ep_type = (read_buf >> XILINX_HW_DISCOVERY_TABLE_TYPE_OFFSET) &
-			XILINX_HW_DISCOVERY_TABLE_TYPE_MASK;
-
-		ep_bar_num  = \
-			(read_buf >> XILINX_HW_DISCOVERY_TABLE_EP_BAR_NUM_OFFSET) &
-			XILINX_HW_DISCOVERY_TABLE_EP_BAR_IDX_MASK; /* BAR Num where the target aperture is located */
-
-		ep_start_addr = \
-			(read_buf >> XILINX_HW_DISCOVERY_TABLE_OFF_LOW_OFFSET) &
-			XILINX_HW_DISCOVERY_TABLE_OFF_LOW_MASK;
-
-		read_buf = ioread32(hw_discovery_virt_addr + i +
-			XILINX_HW_DISCOVERY_TABLE_ENTRY_ROW_1_OFFSET);
-
-		ep_start_addr |= \
-			((uint64_t)((read_buf >> XILINX_HW_DISCOVERY_TABLE_OFF_HIGH_OFFSET) &
-				XILINX_HW_DISCOVERY_TABLE_OFF_HIGH_MASK) <<
-			XILINX_HW_DISCOVERY_TABLE_OFF_LOW_LEN);
-
-		DEV_VDBG(dev,
-			"ep_type : 0x%X, ep_bar_num : 0x%X, ep_start_addr : 0x%llX",
-			ep_type, ep_bar_num, ep_start_addr);
-
-		switch(ep_type) {
+		switch(ep_type[index]) {
 		case XILINX_TABLE_TYPE_UUID0_ROM:
 			(*endpoints)->uuid0_rom.found = \
 				true;
@@ -305,8 +277,7 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 			(*endpoints)->uuid0_rom.bar_num = \
 				ep_bar_num;
 
-			(*endpoints)->uuid0_rom.start_addr = \
-				ep_start_addr;
+			(*endpoints)->uuid0_rom.start_addr = ep_start_addr[0];
 
 			(*endpoints)->uuid0_rom.bar_len = \
 				XILINX_ENDPOINT_BAR_LEN_UUID0_ROM;
@@ -321,29 +292,6 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 			print_endpoint_info(dev, (*endpoints)->uuid0_rom);
 			break;
 
-		case XILINX_TABLE_TYPE_INTER_PF_MAILBOX:
-			(*endpoints)->interpf_mailbox.found = \
-				true;
-
-			(*endpoints)->interpf_mailbox.bar_num = \
-				ep_bar_num;
-
-			(*endpoints)->interpf_mailbox.start_addr = \
-				ep_start_addr;
-
-			(*endpoints)->interpf_mailbox.bar_len = \
-				XILINX_ENDPOINT_BAR_LEN_INTERPF_MAILBOX;
-
-			(*endpoints)->interpf_mailbox.end_addr = \
-				(*endpoints)->interpf_mailbox.start_addr +
-				(*endpoints)->interpf_mailbox.bar_len - 1;
-
-			strcpy((*endpoints)->interpf_mailbox.name,
-				XILINX_ENDPOINT_NAME_INTERPF_MAILBOX_PF0);
-
-			print_endpoint_info(dev, (*endpoints)->interpf_mailbox);
-			break;
-
 		case XILINX_TABLE_TYPE_GCQ:
 			(*endpoints)->gcq.found = \
 				true;
@@ -352,7 +300,7 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 				ep_bar_num;
 
 			(*endpoints)->gcq.start_addr = \
-				ep_start_addr;
+				ep_start_addr[1];
 
 			(*endpoints)->gcq.bar_len = \
 				XILINX_ENDPOINT_BAR_LEN_GCQ;
@@ -373,7 +321,7 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 				ep_bar_num;
 
 			(*endpoints)->gcq_payload.start_addr = \
-				ep_start_addr;
+				ep_start_addr[2];
 
 			(*endpoints)->gcq_payload.bar_len = \
 				XILINX_ENDPOINT_BAR_LEN_GCQ_PAYLOAD;
@@ -402,9 +350,9 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 		}
 	}
 
-	DEV_VDBG(dev, "Unmapping HW discovery BAR memory");
-	pci_iounmap(dev, hw_discovery_virt_addr);
-	hw_discovery_virt_addr = 0;
+	// DEV_VDBG(dev, "Unmapping HW discovery BAR memory");
+	// pci_iounmap(dev, hw_discovery_virt_addr);
+	// hw_discovery_virt_addr = 0;
 
 	ret = read_logic_uuid(dev, endpoints);
 	if (ret)
@@ -414,10 +362,6 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	return SUCCESS;
 
 fail:
-	if (hw_discovery_virt_addr)
-		pci_iounmap(dev, hw_discovery_virt_addr);
-
-	release_vsec_mem(endpoints);
 	DEV_ERR(dev, "Failed to read Vendor Specific Region (VSEC)");
 	return ret;
 }

--- a/sw/AMI/driver/ami_vsec.c
+++ b/sw/AMI/driver/ami_vsec.c
@@ -83,6 +83,9 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	uint32_t table_length = 0, table_entry_size = 0;
 	uint8_t ep_bar_num = 0;
 	uint8_t pcie_function_num = 0;
+	uint32_t ep_type[4]= {XILINX_TABLE_TYPE_UUID0_ROM, XILINX_TABLE_TYPE_GCQ, XILINX_TABLE_TYPE_GCQ_PAYLOAD, XILINX_TABLE_TYPE_END_OF_TABLE};
+	uint32_t ep_start_addr[4] = {UUID0_START_ADDR, GCQ_IP_START_ADDR, GCQ_PAYLOAD_START_ADDR, 0};
+	int index = 0;
 
 	if (!dev || !endpoints)
 		return -EINVAL;
@@ -129,8 +132,8 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	 *  0x40 - 64 byte entry size
 	 *  0x80 - 128 byte entry size
 	 */
-	table_length = TABLE_LEN;
-	table_entry_size = TABLE_ENTRY_SIZE;
+	table_length = FAKE_HW_DISCOVERY_TABLE_LEN;
+	table_entry_size = FAKE_HW_DISCOVERY_TABLE_ENTRY_SIZE;
 
 	/*
 	 *                                         Table Entry
@@ -145,12 +148,9 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	 *     |                                Rsvd[31:0]                                               |
 	 *      -----------------------------------------------------------------------------------------
 	 */
-	int ep_type[3]= {XILINX_TABLE_TYPE_UUID0_ROM,TABLE_TYPE_GCQ_IP,TABLE_TYPE_GCQ_PAYLOAD};
-	int ep_start_addr[3] = {UUID0_START_ADDR, GCQ_IP_START_ADDR,GCQ_PAYLOAD_START_ADDR};
-	int index = 0;
 
 	/* Traverse all the table entry */
-	for (i = 0; i < table_length; i += table_entry_size) {
+	for (i = 0, index = 0; i < table_length; i += table_entry_size, index++) {
 		if (end_of_table)
 			break;
 
@@ -164,7 +164,7 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 			(*endpoints)->uuid0_rom.bar_num = \
 				ep_bar_num;
 
-			(*endpoints)->uuid0_rom.start_addr = ep_start_addr[0];
+			(*endpoints)->uuid0_rom.start_addr = ep_start_addr[index];
 
 			(*endpoints)->uuid0_rom.bar_len = \
 				XILINX_ENDPOINT_BAR_LEN_UUID0_ROM;
@@ -187,7 +187,7 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 				ep_bar_num;
 
 			(*endpoints)->gcq.start_addr = \
-				ep_start_addr[1];
+				ep_start_addr[index];
 
 			(*endpoints)->gcq.bar_len = \
 				XILINX_ENDPOINT_BAR_LEN_GCQ;
@@ -208,7 +208,7 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 				ep_bar_num;
 
 			(*endpoints)->gcq_payload.start_addr = \
-				ep_start_addr[2];
+				ep_start_addr[index];
 
 			(*endpoints)->gcq_payload.bar_len = \
 				XILINX_ENDPOINT_BAR_LEN_GCQ_PAYLOAD;
@@ -230,7 +230,7 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 		default:
 			DEV_ERR(dev,
 				"Found Unsupported or Reserved Type Endpoint: 0x%X",
-				ep_type);
+				ep_type[index]);
 			ret = -EINVAL;
 			goto fail;
 			break;

--- a/sw/AMI/driver/ami_vsec.c
+++ b/sw/AMI/driver/ami_vsec.c
@@ -129,8 +129,8 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	 *  0x40 - 64 byte entry size
 	 *  0x80 - 128 byte entry size
 	 */
-	table_length = 0x40;
-	table_entry_size = 0x10;
+	table_length = TABLE_LEN;
+	table_entry_size = TABLE_ENTRY_SIZE;
 
 	/*
 	 *                                         Table Entry
@@ -145,15 +145,14 @@ int read_vsec(struct pci_dev *dev, uint32_t vsec_base_addr,
 	 *     |                                Rsvd[31:0]                                               |
 	 *      -----------------------------------------------------------------------------------------
 	 */
-	int ep_type[3]= {0x50,0x54,0x55};
-	int ep_start_addr[3] = {0x1001000, 0x1010000,0x8000000};
+	int ep_type[3]= {XILINX_TABLE_TYPE_UUID0_ROM,TABLE_TYPE_GCQ_IP,TABLE_TYPE_GCQ_PAYLOAD};
+	int ep_start_addr[3] = {UUID0_START_ADDR, GCQ_IP_START_ADDR,GCQ_PAYLOAD_START_ADDR};
 	int index = 0;
 
 	/* Traverse all the table entry */
 	for (i = 0; i < table_length; i += table_entry_size) {
 		if (end_of_table)
 			break;
-
 
 		ep_bar_num  = 0x0; /* BAR Num where the target aperture is located */
 

--- a/sw/AMI/driver/ami_vsec.c
+++ b/sw/AMI/driver/ami_vsec.c
@@ -38,17 +38,11 @@ int read_logic_uuid(struct pci_dev *dev, endpoints_struct **endpoints)
 		goto fail;
 	}
 
-	printk("uuid0_rom.bar_num %x", (*endpoints)->uuid0_rom.bar_num);
-	printk("uuid0_rom.start_addr %x", (*endpoints)->uuid0_rom.start_addr);
-	printk("uuid0_rom.bar_len %x", (*endpoints)->uuid0_rom.bar_len);
-
 	virt_addr = pci_iomap_range(dev,
 		(*endpoints)->uuid0_rom.bar_num,
 		(*endpoints)->uuid0_rom.start_addr,
 		(*endpoints)->uuid0_rom.bar_len);
 
-	printk("virt_addr %x", virt_addr);
-	printk("dev %x", dev);
 	if (!virt_addr) {
 		DEV_ERR(dev, "Could not map %s endpoint into virtual memory at start address 0x%llX",
 			(*endpoints)->uuid0_rom.name, (*endpoints)->uuid0_rom.start_addr);

--- a/sw/AMI/driver/ami_vsec.h
+++ b/sw/AMI/driver/ami_vsec.h
@@ -103,14 +103,14 @@ enum xil_table_type {
 };
 
 typedef struct {
-	endpoint_info_struct hw_discovery;       
-	endpoint_info_struct uuid0_rom;          
-	endpoint_info_struct interpf_mailbox;    
-	endpoint_info_struct gcq;                
-	endpoint_info_struct gcq_payload;        
+	endpoint_info_struct hw_discovery;
+	endpoint_info_struct uuid0_rom;
+	endpoint_info_struct interpf_mailbox;
+	endpoint_info_struct gcq;
+	endpoint_info_struct gcq_payload;
 
-	uint32_t logic_uuid      [XILINX_LOGIC_UUID_SIZE_BYTES/sizeof(uint32_t)];   
-	char     logic_uuid_str  [XILINX_LOGIC_UUID_SIZE_BYTES*2+1];                
+	uint32_t logic_uuid      [XILINX_LOGIC_UUID_SIZE_BYTES/sizeof(uint32_t)];
+	char     logic_uuid_str  [XILINX_LOGIC_UUID_SIZE_BYTES*2+1];
 } endpoints_struct;
 
 int read_logic_uuid(struct pci_dev *dev, endpoints_struct **endpoints);

--- a/sw/AMI/driver/ami_vsec.h
+++ b/sw/AMI/driver/ami_vsec.h
@@ -82,20 +82,18 @@
 #define XILINX_LOGIC_UUID_SIZE_BYTES                16
 
 // Hardcoded Regions
-#define GCQ_IP_BAR_NUM      	0x0
-#define GCQ_IP_BAR_LEN      	0x1000
-#define GCQ_IP_START_ADDR   	0x1010000
+#define GCQ_IP_BAR_NUM          0x0
+#define GCQ_IP_BAR_LEN          0x1000
+#define GCQ_IP_START_ADDR       0x1010000
 
 #define GCQ_PAYLOAD_BAR_NUM     0x0
 #define GCQ_PAYLOAD_BAR_LEN     0x8000000
 #define GCQ_PAYLOAD_START_ADDR  0x8000000
 
-#define UUID0_START_ADDR 		0x1001000
+#define UUID0_START_ADDR        0x1001000
 
-#define TABLE_LEN 				0x40
-#define TABLE_ENTRY_SIZE 		0x10
-#define TABLE_TYPE_GCQ_IP 		0x54
-#define TABLE_TYPE_GCQ_PAYLOAD	0x55
+#define FAKE_HW_DISCOVERY_TABLE_LEN               0x40
+#define FAKE_HW_DISCOVERY_TABLE_ENTRY_SIZE        0x10
 
 enum xil_table_type {
 	XILINX_TABLE_TYPE_RSVD              = 0x00,

--- a/sw/AMI/driver/ami_vsec.h
+++ b/sw/AMI/driver/ami_vsec.h
@@ -103,14 +103,14 @@ enum xil_table_type {
 };
 
 typedef struct {
-	endpoint_info_struct hw_discovery;
-	endpoint_info_struct uuid0_rom;
-	endpoint_info_struct interpf_mailbox;
-	endpoint_info_struct gcq;
-	endpoint_info_struct gcq_payload;
+	endpoint_info_struct hw_discovery;       
+	endpoint_info_struct uuid0_rom;          
+	endpoint_info_struct interpf_mailbox;    
+	endpoint_info_struct gcq;                
+	endpoint_info_struct gcq_payload;        
 
-	uint32_t logic_uuid      [XILINX_LOGIC_UUID_SIZE_BYTES/sizeof(uint32_t)];
-	char     logic_uuid_str  [XILINX_LOGIC_UUID_SIZE_BYTES*2+1];
+	uint32_t logic_uuid      [XILINX_LOGIC_UUID_SIZE_BYTES/sizeof(uint32_t)];   
+	char     logic_uuid_str  [XILINX_LOGIC_UUID_SIZE_BYTES*2+1];                
 } endpoints_struct;
 
 int read_logic_uuid(struct pci_dev *dev, endpoints_struct **endpoints);

--- a/sw/AMI/driver/ami_vsec.h
+++ b/sw/AMI/driver/ami_vsec.h
@@ -81,6 +81,22 @@
 
 #define XILINX_LOGIC_UUID_SIZE_BYTES                16
 
+// Hardcoded Regions
+#define GCQ_IP_BAR_NUM      	0x0
+#define GCQ_IP_BAR_LEN      	0x1000
+#define GCQ_IP_START_ADDR   	0x1010000
+
+#define GCQ_PAYLOAD_BAR_NUM     0x0
+#define GCQ_PAYLOAD_BAR_LEN     0x8000000
+#define GCQ_PAYLOAD_START_ADDR  0x8000000
+
+#define UUID0_START_ADDR 		0x1001000
+
+#define TABLE_LEN 				0x40
+#define TABLE_ENTRY_SIZE 		0x10
+#define TABLE_TYPE_GCQ_IP 		0x54
+#define TABLE_TYPE_GCQ_PAYLOAD	0x55
+
 enum xil_table_type {
 	XILINX_TABLE_TYPE_RSVD              = 0x00,
 	XILINX_TABLE_TYPE_PCIE_IP_VERSION,
@@ -103,14 +119,14 @@ enum xil_table_type {
 };
 
 typedef struct {
-	endpoint_info_struct hw_discovery;       
-	endpoint_info_struct uuid0_rom;          
-	endpoint_info_struct interpf_mailbox;    
-	endpoint_info_struct gcq;                
-	endpoint_info_struct gcq_payload;        
+	endpoint_info_struct hw_discovery;
+	endpoint_info_struct uuid0_rom;
+	endpoint_info_struct interpf_mailbox;
+	endpoint_info_struct gcq;
+	endpoint_info_struct gcq_payload;
 
-	uint32_t logic_uuid      [XILINX_LOGIC_UUID_SIZE_BYTES/sizeof(uint32_t)];   
-	char     logic_uuid_str  [XILINX_LOGIC_UUID_SIZE_BYTES*2+1];                
+	uint32_t logic_uuid      [XILINX_LOGIC_UUID_SIZE_BYTES/sizeof(uint32_t)];
+	char     logic_uuid_str  [XILINX_LOGIC_UUID_SIZE_BYTES*2+1];
 } endpoints_struct;
 
 int read_logic_uuid(struct pci_dev *dev, endpoints_struct **endpoints);


### PR DESCRIPTION
Removing access to hardware discovery: the module is simply hardcoded values in the hardware
we are doing this in order to prepare the tandem PCIE flow. That implies removing external interface and extended configuration space.