### PR TITLE
[FEATURE] Adding support for Almalinux

### DIFF
--- a/sw/AMI/driver/Makefile
+++ b/sw/AMI/driver/Makefile
@@ -10,9 +10,9 @@ DISTRO_ID := $(shell grep -E '^ID=' /etc/os-release 2>/dev/null | cut -d'=' -f2 
 
 # Set distribution-specific flags
 ifeq ($(DISTRO_ID),ubuntu)
-    DISTRO_FLAGS = -DDISTRO_UBUNTU=1 -DDISTRO_ALMALINUX=0
+    DISTRO_FLAGS = -DDISTRO_UBUNTU=1
 else ifeq ($(DISTRO_ID),almalinux)
-    DISTRO_FLAGS = -DDISTRO_ALMALINUX=1 -DDISTRO_UBUNTU=0
+    DISTRO_FLAGS = -DDISTRO_ALMALINUX=1
 else
     $(error Only Almalinux and Ubuntu are supported.)
 endif

--- a/sw/AMI/driver/Makefile
+++ b/sw/AMI/driver/Makefile
@@ -5,6 +5,20 @@ TARGET_MODULE:=ami
 
 #define VERBOSE_DEBUG 1
 
+# Detect distribution automatically
+DISTRO_ID := $(shell grep -E '^ID=' /etc/os-release 2>/dev/null | cut -d'=' -f2 | tr -d '"')
+
+# Set distribution-specific flags
+ifeq ($(DISTRO_ID),ubuntu)
+    DISTRO_FLAGS = -DDISTRO_UBUNTU=1 -DDISTRO_ALMALINUX=0
+else ifeq ($(DISTRO_ID),almalinux)
+    DISTRO_FLAGS = -DDISTRO_ALMALINUX=1 -DDISTRO_UBUNTU=0
+else
+    $(error Only Almalinux and Ubuntu are supported.)
+endif
+
+$(info $(DISTRO_ID) has been detected, Continuing ...)
+
 obj-m += $(TARGET_MODULE).o
 
 $(TARGET_MODULE)-objs += ami_top.o
@@ -38,7 +52,7 @@ KERNEL_DIR = /lib/modules/`uname -r`/build
 
 #To apply the macro to all the source files compiled with this makefile
 # ccflags-y:=-DDEBUG
-ccflags-y:=-DDEBUG -DVERBOSE_DEBUG -DGCQ_MAX_INSTANCES=16
+ccflags-y:=-DDEBUG -DVERBOSE_DEBUG -DGCQ_MAX_INSTANCES=16 $(DISTRO_FLAGS)
 
 all: clean
 	$(MAKE) -C ${KERNEL_DIR} M=${PWD} modules

--- a/sw/AMI/driver/ami_cdev.c
+++ b/sw/AMI/driver/ami_cdev.c
@@ -43,7 +43,11 @@ static int dev_major = 0;  /* This will be overridden. */
  *
  * Return: NULL.
  */
+#ifdef IS_ALMALINUX
 static char *devnode(const struct device *dev, umode_t *mode)
+#elif IS_UBUNTU
+static char *devnode(struct device *dev, umode_t *mode)
+#endif
 {
     if (mode)
         *mode = READ_WRITE;
@@ -848,7 +852,11 @@ int create_cdev(unsigned baseminor, struct drv_cdev_struct *drv_cdev,
 
     if(!drv_cdev->dev_class) {
         cls_created = true;
+        #ifdef IS_ALMALINUX
         drv_cdev->dev_class = class_create(drv_cdev->drv_cls_str);
+        #elif IS_UBUNTU
+        drv_cdev->dev_class = class_create(THIS_MODULE, drv_cdev->drv_cls_str);
+        #endif
         if (IS_ERR(drv_cdev->dev_class)) {
             ret = PTR_ERR(drv_cdev->dev_class);
             PR_ERR("Failed to create class %s. ret : %d",

--- a/sw/AMI/driver/ami_cdev.c
+++ b/sw/AMI/driver/ami_cdev.c
@@ -33,7 +33,7 @@
 #define IS_ROOT_USER(uid, euid)  (capable(CAP_DAC_OVERRIDE) || (uid == ROOT_USER) || (euid == ROOT_USER))
 
 
-static int dev_major = 0;  /* This will be overriden. */
+static int dev_major = 0;  /* This will be overridden. */
 
 
 /**
@@ -43,7 +43,7 @@ static int dev_major = 0;  /* This will be overriden. */
  *
  * Return: NULL.
  */
-static char *devnode(struct device *dev, umode_t *mode)
+static char *devnode(const struct device *dev, umode_t *mode)
 {
     if (mode)
         *mode = READ_WRITE;
@@ -848,7 +848,7 @@ int create_cdev(unsigned baseminor, struct drv_cdev_struct *drv_cdev,
 
     if(!drv_cdev->dev_class) {
         cls_created = true;
-        drv_cdev->dev_class = class_create(THIS_MODULE, drv_cdev->drv_cls_str);
+        drv_cdev->dev_class = class_create(drv_cdev->drv_cls_str);
         if (IS_ERR(drv_cdev->dev_class)) {
             ret = PTR_ERR(drv_cdev->dev_class);
             PR_ERR("Failed to create class %s. ret : %d",

--- a/sw/AMI/driver/ami_program.c
+++ b/sw/AMI/driver/ami_program.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
  * ami_program.c - This file contains functions to program (flash) devices.
- * 
+ *
  * Copyright (c) 2023-present Advanced Micro Devices, Inc. All rights reserved.
  */
 
@@ -46,7 +46,7 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 	/* Round up the total number of chunks */
 	uint16_t num_chunks = (size + ((PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER) - 1)) /
 		(PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER);
-	
+
 	if (!size || !amc_ctrl_ctxt || !buf)
 		return -EINVAL;
 
@@ -71,7 +71,7 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 			bytes_to_write = (size - bytes_written);
 		else
 			bytes_to_write = (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER);
-		
+
 		/*
 		 * Don't invalidate the boot tag if we're updating the FPT
 		 * or if there is only a single chunk.
@@ -86,11 +86,11 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 				MK_PDI_FLAGS(boot_device, part, chunk, (!rewrite_boot_tag && (chunk == (num_chunks - 1)))),
 				&buf[bytes_written], bytes_to_write);
 
-			if (ret) 
+			if (ret)
 				break;
 
 			if (efd_ctx)
-				eventfd_signal(efd_ctx, bytes_to_write);
+				eventfd_signal(efd_ctx);
 		} else {
 			uint32_t boot_tag = INVALID_BOOT_TAG;
 
@@ -106,7 +106,7 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 			ret = submit_gcq_command(amc_ctrl_ctxt, GCQ_SUBMIT_CMD_DOWNLOAD_PDI,
 				MK_PDI_FLAGS(boot_device, part, BOOT_TAG_CHUNK, false),
 				(uint8_t*)&boot_tag, sizeof(uint32_t));
-			
+
 			/*
 			 * Don't signal to the user here but we do increment
 			 * the chunk and number of bytes written so we can continue
@@ -114,7 +114,7 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 			 */
 			if (ret)
 				break;
-			
+
 			rewrite_boot_tag = true;
 		}
 
@@ -144,7 +144,7 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 			buf, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
 
 		if (!ret && efd_ctx)
-			eventfd_signal(efd_ctx, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
+		    eventfd_signal(efd_ctx);
 	}
 
 	if (ret)
@@ -226,7 +226,7 @@ int device_boot(struct pf_dev_struct *pf_dev, uint32_t partition)
 
 	ret = submit_gcq_command(pf_dev->amc_ctrl_ctxt, GCQ_SUBMIT_CMD_DEVICE_BOOT,
 		partition, NULL, 0);
-	
+
 	if (ret)
 		AMI_ERR(pf_dev->amc_ctrl_ctxt, "Failed to select boot partition");
 
@@ -258,7 +258,7 @@ int copy_partition(struct pf_dev_struct *pf_dev, uint32_t src_device, uint32_t s
 			AMI_ERR(pf_dev->amc_ctrl_ctxt, "Partition not found");
 			return -EINVAL;
 	}
-	
+
 	/* Sanity check partition size */
 	if (dest_partition.partition_size < src_partition.partition_size) {
 		AMI_ERR(pf_dev->amc_ctrl_ctxt, "Destination partition is too small for copy");
@@ -271,7 +271,7 @@ int copy_partition(struct pf_dev_struct *pf_dev, uint32_t src_device, uint32_t s
 	 */
 	ret = submit_gcq_command(pf_dev->amc_ctrl_ctxt, GCQ_SUBMIT_CMD_COPY_PARTITION,
 		MK_PARTITION_FLAGS(src_device, src_part, dest_device, dest_part), NULL, src_partition.partition_size);
-	
+
 	if (ret)
 		AMI_ERR(pf_dev->amc_ctrl_ctxt, "Failed to copy partition");
 

--- a/sw/AMI/driver/ami_program.c
+++ b/sw/AMI/driver/ami_program.c
@@ -90,7 +90,11 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 				break;
 
 			if (efd_ctx)
-				eventfd_signal(efd_ctx);
+                #ifdef IS_ALMALINUX
+                eventfd_signal(efd_ctx);
+                #elif IS_UBUNTU
+                eventfd_signal(efd_ctx, bytes_to_write);
+                #endif
 		} else {
 			uint32_t boot_tag = INVALID_BOOT_TAG;
 
@@ -144,7 +148,11 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 			buf, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
 
 		if (!ret && efd_ctx)
-		    eventfd_signal(efd_ctx);
+            #ifdef IS_ALMALINUX
+            eventfd_signal(efd_ctx);
+            #elif IS_UBUNTU
+            eventfd_signal(efd_ctx, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
+            #endif
 	}
 
 	if (ret)

--- a/sw/AMI/driver/ami_top.c
+++ b/sw/AMI/driver/ami_top.c
@@ -992,7 +992,7 @@ static ssize_t ami_debug_enabled_store(struct device_driver *drv, const char *bu
     if (count > AMI_DEBUG_INPUT_LIMIT)
         return -EINVAL;
 
-    sscanf(buf, "%hhd", &set_output_status);
+    sscanf(buf, "%d", &set_output_status);
     ami_debug_enabled = set_output_status;
 
     return count;

--- a/sw/AMI/driver/ami_top.h
+++ b/sw/AMI/driver/ami_top.h
@@ -39,7 +39,7 @@
  * @PF_DEV_STATE_INIT_ERROR: AMC setup and device may be used but with no data.
  * @PF_DEV_STATE_SHUTDOWN: All services have been shutdown.
  * @PF_DEV_STATE_COMPAT: Compatibility mode - most functions unavailable.
- * 
+ *
  * Note that, currently, PF_DEV_STATE_INIT is only used temporarily within
  * the device probe function so a user is unlikely to ever see this state.
  */
@@ -175,7 +175,7 @@ int add_pf_dev_app(struct pf_dev_struct *pf_dev, struct task_struct *task);
  * delete_pf_dev_app() - Remove a user application from a device.
  * @pf_dev: The device handle.
  * @task: The task struct this application belongs to.
- * 
+ *
  * If the application does not exist, this function does nothing and
  * returns success.
  *
@@ -195,11 +195,18 @@ struct pf_dev_struct *get_pf_dev_entry(void *cache, enum pf_dev_cache_type cache
 /**
  * put_pf_dev_entry() - Decrement the reference count of a pf_dev_struct
  * @pf_dev: Pointer to data struct.
- * 
+ *
  * If this is the last pointer reference, all device data will be deleted.
  *
  * Return: None
  */
 void put_pf_dev_entry(struct pf_dev_struct *pf_dev);
+
+// Definition of distribution detection macros
+#ifdef DISTRO_UBUNTU
+    #define IS_UBUNTU 1
+#elif DISTRO_ALMALINUX
+    #define IS_ALMALINUX 1
+#endif
 
 #endif /* AMI_TOP_H */


### PR DESCRIPTION
Because almalinux and ubuntu have a close kernel version number, we check instead `/etc/os-release` in order to know in which distribution we are
